### PR TITLE
Add Main Color Power properties for decal emission

### DIFF
--- a/Editor/CustomInspector.cs
+++ b/Editor/CustomInspector.cs
@@ -44,10 +44,12 @@ namespace lilToon
         // Number Decal Emission Mask and Color
         MaterialProperty _DecalNumberEmissionMask;
         MaterialProperty _DecalNumberEmissionColor;
+        MaterialProperty _DecalNumberMainColorPower;
         
         // Texture Decal Emission Mask and Color
         MaterialProperty _DecalTextureEmissionMask;
         MaterialProperty _DecalTextureEmissionColor;
+        MaterialProperty _DecalTextureMainColorPower;
 
         private static bool isShowCustomProperties;
         private const string shaderName = "ChiseNote/DecalHeartRate";
@@ -97,8 +99,10 @@ namespace lilToon
             // Load new emission properties
             _DecalNumberEmissionMask = FindProperty("_DecalNumberEmissionMask", props);
             _DecalNumberEmissionColor = FindProperty("_DecalNumberEmissionColor", props);
+            _DecalNumberMainColorPower = FindProperty("_DecalNumberMainColorPower", props);
             _DecalTextureEmissionMask = FindProperty("_DecalTextureEmissionMask", props);
             _DecalTextureEmissionColor = FindProperty("_DecalTextureEmissionColor", props);
+            _DecalTextureMainColorPower = FindProperty("_DecalTextureMainColorPower", props);
         }
         protected override void DrawCustomProperties(Material material)
         {
@@ -307,6 +311,9 @@ namespace lilToon
                     EditorGUILayout.Space(3);
                     m_MaterialEditor.ShaderProperty(_DecalNumberEmissionStrength, "Basic Emission Power");
                     EditorGUILayout.Space(3);
+                    // Main Color Power: blend emission color from black to the chosen color (0..1)
+                    m_MaterialEditor.ShaderProperty(_DecalNumberMainColorPower, "Main Color Power");
+                    EditorGUILayout.Space(3);
                     m_MaterialEditor.ShaderProperty(_UseHeartRateEmission, "Heart Rate Emission");
                     if(_UseHeartRateEmission.floatValue == 1)
                     {
@@ -393,6 +400,9 @@ namespace lilToon
                     m_MaterialEditor.TexturePropertySingleLine(new GUIContent("Color / Mask", "Controls which areas emit light"), _DecalTextureEmissionMask, _DecalTextureEmissionColor);
                     EditorGUILayout.Space(3);
                     m_MaterialEditor.ShaderProperty(_DecalTextureEmissionStrength, "Basic Emission Power");
+                    EditorGUILayout.Space(3);
+                    // Main Color Power: blend emission color from black to the chosen color (0..1)
+                    m_MaterialEditor.ShaderProperty(_DecalTextureMainColorPower, "Main Color Power");
                     EditorGUILayout.Space(3);
                     m_MaterialEditor.ShaderProperty(_UseHeartRateEmissionTexture, "Heart Rate Emission");
                     if(_UseHeartRateEmissionTexture.floatValue == 1)

--- a/Shaders/custom.hlsl
+++ b/Shaders/custom.hlsl
@@ -36,7 +36,9 @@
     float _DecalNumberEmissionStrength; \
     float _DecalTextureEmissionStrength; \
     float4 _DecalNumberEmissionColor; \
+    float _DecalNumberMainColorPower; \
     float4 _DecalTextureEmissionColor; \
+    float _DecalTextureMainColorPower; \
     bool _UseHeartRateEmission; \
     float _HeartRateEmissionMin; \
     float _HeartRateEmissionMax; \

--- a/Shaders/custom_insert.hlsl
+++ b/Shaders/custom_insert.hlsl
@@ -288,13 +288,10 @@ void lilGetDecalTexture(inout lilFragData fd LIL_SAMP_IN_FUNC(samp))
         
         if (emissionStrength > 0.0)
         {
-            // sample emission mask and apply emission color
             float4 maskSample = LIL_SAMPLE_2D(_DecalTextureEmissionMask, sampler_DecalTextureEmissionMask, uv2);
-            float maskValue = maskSample.r; // use red channel as mask
+            float maskValue = maskSample.r; 
             float3 emissionCol = _DecalTextureEmissionColor.rgb;
-            // apply Main Color Power: replace emission color with decal tint color
             emissionCol = lerp(emissionCol, _DecalTextureColor.rgb, _DecalTextureMainColorPower);
-            // multiply by decal alpha mask as well to keep original decal shape
             float finalMask = decalMask * maskValue;
             fd.emissionColor += emissionCol * (emissionStrength * kEmissionScale) * finalMask;
         }
@@ -334,12 +331,9 @@ void lilGetDecalNumber(inout lilFragData fd LIL_SAMP_IN_FUNC(samp))
         
         if (emissionStrength > 0.0)
         {
-            // sample emission mask for numbers (using same UV as number sampling)
-            // number mask texture uses _DecalNumberEmissionMask; sample with numUv
             float4 maskSample = LIL_SAMPLE_2D(_DecalNumberEmissionMask, sampler_DecalNumberEmissionMask, numUv);
             float maskValue = maskSample.r;
             float3 emissionCol = _DecalNumberEmissionColor.rgb;
-            // apply Main Color Power: replace emission color with number texture tint color
             emissionCol = lerp(emissionCol, _SpriteNumberTextureColor.rgb, _DecalNumberMainColorPower);
             float finalMask = numberMask * maskValue;
             fd.emissionColor += emissionCol * (emissionStrength * kEmissionScale) * finalMask;

--- a/Shaders/custom_insert.hlsl
+++ b/Shaders/custom_insert.hlsl
@@ -292,6 +292,8 @@ void lilGetDecalTexture(inout lilFragData fd LIL_SAMP_IN_FUNC(samp))
             float4 maskSample = LIL_SAMPLE_2D(_DecalTextureEmissionMask, sampler_DecalTextureEmissionMask, uv2);
             float maskValue = maskSample.r; // use red channel as mask
             float3 emissionCol = _DecalTextureEmissionColor.rgb;
+            // apply Main Color Power: replace emission color with decal tint color
+            emissionCol = lerp(emissionCol, _DecalTextureColor.rgb, _DecalTextureMainColorPower);
             // multiply by decal alpha mask as well to keep original decal shape
             float finalMask = decalMask * maskValue;
             fd.emissionColor += emissionCol * (emissionStrength * kEmissionScale) * finalMask;
@@ -336,7 +338,9 @@ void lilGetDecalNumber(inout lilFragData fd LIL_SAMP_IN_FUNC(samp))
             // number mask texture uses _DecalNumberEmissionMask; sample with numUv
             float4 maskSample = LIL_SAMPLE_2D(_DecalNumberEmissionMask, sampler_DecalNumberEmissionMask, numUv);
             float maskValue = maskSample.r;
-            float3 emissionCol = _DecalNumberEmissionColor.rgb; // use user-specified emission color for numbers
+            float3 emissionCol = _DecalNumberEmissionColor.rgb;
+            // apply Main Color Power: replace emission color with number texture tint color
+            emissionCol = lerp(emissionCol, _SpriteNumberTextureColor.rgb, _DecalNumberMainColorPower);
             float finalMask = numberMask * maskValue;
             fd.emissionColor += emissionCol * (emissionStrength * kEmissionScale) * finalMask;
         }

--- a/Shaders/lilCustomShaderProperties.lilblock
+++ b/Shaders/lilCustomShaderProperties.lilblock
@@ -25,6 +25,7 @@ _FloatHeartRateC                         ("HeartRate", float) = 0
                 _DecalNumberEmissionStrength ("Emission Strength", Range(0, 100)) = 0
                 _DecalNumberEmissionMask     ("Emission Mask", 2D) = "white" {}
 [HDR][lilHDR]   _DecalNumberEmissionColor    ("Emission Color", Color) = (1,1,1,1)
+                _DecalNumberMainColorPower   ("Main Color Power", Range(0, 1)) = 1
 
 // Heart Rate Emission Control
 [lilToggle]     _UseHeartRateEmission       ("Use HeartRate Emission", Int) = 0
@@ -45,6 +46,7 @@ _FloatHeartRateC                         ("HeartRate", float) = 0
                 _DecalTextureEmissionStrength ("Emission Strength", Range(0, 100)) = 0
                 _DecalTextureEmissionMask     ("Emission Mask", 2D) = "white" {}
 [HDR][lilHDR]   _DecalTextureEmissionColor    ("Emission Color", Color) = (1,1,1,1)
+                _DecalTextureMainColorPower   ("Main Color Power", Range(0, 1)) = 0
 
 // Heart Rate Emission Control (also applies to texture)
 [lilToggle]     _UseHeartRateEmissionTexture ("Use HeartRate Emission", Int) = 0


### PR DESCRIPTION
## Changes

- Add Main Color Power properties for Number Decal and Texture Decal emissions
- Implement color blending between emission colors and specified tint colors
- Replace color multiplication with direct color replacement to prevent darkening
- Expose Main Color Power sliders in custom inspector under Emission sections
- Update shader logic to use lilToon-style color interpolation for enhanced control
- Enhance decal appearance control in the rendering process

## Related Topic
