### PR TITLE
Add visibility controls for decals with thresholds

### DIFF
--- a/Editor/CustomInspector.cs
+++ b/Editor/CustomInspector.cs
@@ -42,6 +42,8 @@ namespace lilToon
         MaterialProperty _UseHeartRateScaleTexture;
         MaterialProperty _HeartRateScaleIntensity;
         MaterialProperty _DecalNumberVisibilityThreshold;
+        MaterialProperty _HideDecalTextureWhenZero;
+        MaterialProperty _DecalTextureVisibilityThreshold;
         
         // Number Decal Emission Mask and Color
         MaterialProperty _DecalNumberEmissionMask;
@@ -101,6 +103,8 @@ namespace lilToon
             _UseHeartRateScaleTexture = FindProperty("_UseHeartRateScaleTexture", props);
             _HeartRateScaleIntensity = FindProperty("_HeartRateScaleIntensity", props);
             _DecalNumberVisibilityThreshold = FindProperty("_DecalNumberVisibilityThreshold", props);
+            _HideDecalTextureWhenZero = FindProperty("_HideDecalTextureWhenZero", props);
+            _DecalTextureVisibilityThreshold = FindProperty("_DecalTextureVisibilityThreshold", props);
             
             // Load new emission properties
             _DecalNumberEmissionMask = FindProperty("_DecalNumberEmissionMask", props);
@@ -370,6 +374,18 @@ namespace lilToon
 
                     DrawLine();
 
+                    // Visibility Settings
+                    EditorGUILayout.LabelField("Visibility", EditorStyles.boldLabel);
+                    EditorGUI.indentLevel++;
+                    m_MaterialEditor.ShaderProperty(_HideDecalTextureWhenZero, "Visibility Mode");
+                    if(_HideDecalTextureWhenZero.floatValue == 1)
+                    {
+                        m_MaterialEditor.ShaderProperty(_DecalTextureVisibilityThreshold, "Threshold Value");
+                    }
+                    EditorGUI.indentLevel--;
+
+                    DrawLine();
+
                     // Transform Settings
                     EditorGUILayout.LabelField("Transform", EditorStyles.boldLabel);
                     EditorGUI.indentLevel++;
@@ -410,7 +426,7 @@ namespace lilToon
 
                     // Rotation
                     m_MaterialEditor.ShaderProperty(_DecalRotation, "Rotation Angle");
-                    EditorGUI.indentLevel--;                    DrawLine();
+                    EditorGUI.indentLevel--;
 
                     // Emission Settings
                     EditorGUILayout.LabelField("Emission", EditorStyles.boldLabel);

--- a/Editor/CustomInspector.cs
+++ b/Editor/CustomInspector.cs
@@ -42,8 +42,13 @@ namespace lilToon
         MaterialProperty _UseHeartRateScaleTexture;
         MaterialProperty _HeartRateScaleIntensity;
         MaterialProperty _DecalNumberVisibilityThreshold;
+        MaterialProperty _DecalNumberThresholdAffectsDisplay;
+        MaterialProperty _DecalNumberThresholdAffectsEmission;
         MaterialProperty _HideDecalTextureWhenZero;
         MaterialProperty _DecalTextureVisibilityThreshold;
+        MaterialProperty _DecalTextureThresholdAffectsDisplay;
+        MaterialProperty _DecalTextureThresholdAffectsEmission;
+        MaterialProperty _DecalTextureThresholdAffectsScale;
         
         // Number Decal Emission Mask and Color
         MaterialProperty _DecalNumberEmissionMask;
@@ -103,8 +108,13 @@ namespace lilToon
             _UseHeartRateScaleTexture = FindProperty("_UseHeartRateScaleTexture", props);
             _HeartRateScaleIntensity = FindProperty("_HeartRateScaleIntensity", props);
             _DecalNumberVisibilityThreshold = FindProperty("_DecalNumberVisibilityThreshold", props);
+            _DecalNumberThresholdAffectsDisplay = FindProperty("_DecalNumberThresholdAffectsDisplay", props);
+            _DecalNumberThresholdAffectsEmission = FindProperty("_DecalNumberThresholdAffectsEmission", props);
             _HideDecalTextureWhenZero = FindProperty("_HideDecalTextureWhenZero", props);
             _DecalTextureVisibilityThreshold = FindProperty("_DecalTextureVisibilityThreshold", props);
+            _DecalTextureThresholdAffectsDisplay = FindProperty("_DecalTextureThresholdAffectsDisplay", props);
+            _DecalTextureThresholdAffectsEmission = FindProperty("_DecalTextureThresholdAffectsEmission", props);
+            _DecalTextureThresholdAffectsScale = FindProperty("_DecalTextureThresholdAffectsScale", props);
             
             // Load new emission properties
             _DecalNumberEmissionMask = FindProperty("_DecalNumberEmissionMask", props);
@@ -266,6 +276,9 @@ namespace lilToon
                     if(_HideDecalNumberWhenZero.floatValue == 1)
                     {
                         m_MaterialEditor.ShaderProperty(_DecalNumberVisibilityThreshold, "Threshold Value");
+                        EditorGUILayout.Space(3);
+                        m_MaterialEditor.ShaderProperty(_DecalNumberThresholdAffectsDisplay, "Apply Threshold To Display");
+                        m_MaterialEditor.ShaderProperty(_DecalNumberThresholdAffectsEmission, "Apply Threshold To Emission");
                     }
                     EditorGUI.indentLevel--;
 
@@ -381,6 +394,10 @@ namespace lilToon
                     if(_HideDecalTextureWhenZero.floatValue == 1)
                     {
                         m_MaterialEditor.ShaderProperty(_DecalTextureVisibilityThreshold, "Threshold Value");
+                        EditorGUILayout.Space(3);
+                        m_MaterialEditor.ShaderProperty(_DecalTextureThresholdAffectsDisplay, "Apply Threshold To Display");
+                        m_MaterialEditor.ShaderProperty(_DecalTextureThresholdAffectsEmission, "Apply Threshold To Emission");
+                        m_MaterialEditor.ShaderProperty(_DecalTextureThresholdAffectsScale, "Apply Threshold To Scale");
                     }
                     EditorGUI.indentLevel--;
 

--- a/Editor/CustomInspector.cs
+++ b/Editor/CustomInspector.cs
@@ -41,6 +41,7 @@ namespace lilToon
         MaterialProperty _HeartRateEmissionMaxTexture;
         MaterialProperty _UseHeartRateScaleTexture;
         MaterialProperty _HeartRateScaleIntensity;
+        MaterialProperty _DecalNumberVisibilityThreshold;
         
         // Number Decal Emission Mask and Color
         MaterialProperty _DecalNumberEmissionMask;
@@ -99,6 +100,7 @@ namespace lilToon
             _HeartRateEmissionMaxTexture = FindProperty("_HeartRateEmissionMaxTexture", props);
             _UseHeartRateScaleTexture = FindProperty("_UseHeartRateScaleTexture", props);
             _HeartRateScaleIntensity = FindProperty("_HeartRateScaleIntensity", props);
+            _DecalNumberVisibilityThreshold = FindProperty("_DecalNumberVisibilityThreshold", props);
             
             // Load new emission properties
             _DecalNumberEmissionMask = FindProperty("_DecalNumberEmissionMask", props);
@@ -257,6 +259,10 @@ namespace lilToon
                     EditorGUILayout.LabelField("Visibility", EditorStyles.boldLabel);
                     EditorGUI.indentLevel++;
                     m_MaterialEditor.ShaderProperty(_HideDecalNumberWhenZero, "Visibility Mode");
+                    if(_HideDecalNumberWhenZero.floatValue == 1)
+                    {
+                        m_MaterialEditor.ShaderProperty(_DecalNumberVisibilityThreshold, "Threshold Value");
+                    }
                     EditorGUI.indentLevel--;
 
                     DrawLine();

--- a/Shaders/custom.hlsl
+++ b/Shaders/custom.hlsl
@@ -15,6 +15,7 @@
 bool _ActiveDecalNumber; \
 bool _ActiveDecalTexture; \
 int _HideDecalNumberWhenZero; \
+int _HideDecalTextureWhenZero; \
 float4 _SpriteNumberTextureColor; \
 float4 _DecalTextureColor; \
 uint _DecalTextureBlendMode; \
@@ -50,6 +51,7 @@ float _HeartRateEmissionMinTexture; \
 float _HeartRateEmissionMaxTexture; \
 bool _UseHeartRateScaleTexture; \
 float _DecalNumberVisibilityThreshold; \
+float _DecalTextureVisibilityThreshold; \
 float _HeartRateScaleIntensity;
 
 // Custom textures

--- a/Shaders/custom.hlsl
+++ b/Shaders/custom.hlsl
@@ -52,6 +52,11 @@ float _HeartRateEmissionMaxTexture; \
 bool _UseHeartRateScaleTexture; \
 float _DecalNumberVisibilityThreshold; \
 float _DecalTextureVisibilityThreshold; \
+int _DecalNumberThresholdAffectsDisplay; \
+int _DecalNumberThresholdAffectsEmission; \
+int _DecalTextureThresholdAffectsDisplay; \
+int _DecalTextureThresholdAffectsEmission; \
+int _DecalTextureThresholdAffectsScale; \
 float _HeartRateScaleIntensity;
 
 // Custom textures

--- a/Shaders/custom.hlsl
+++ b/Shaders/custom.hlsl
@@ -3,64 +3,65 @@
 
 // URP & HDRP compatibility
 #define BEFORE_INCLUDE_COMMON \
-    #if !defined(LIL_PASS_FORWARD_NORMAL_INCLUDED) && !defined(LIL_PASS_FORWARD_NORMAL_INCLUDED_INCLUDED) \
-        #define sampler_linear_repeat sampler_LinearRepeat \
-        #define sampler_linear_clamp sampler_LinearClamp \
-        #define TEXTURE2D_SAMPLER2D(tex,samp) TEXTURE2D(tex), SAMPLER(samp) \
-        #define SAMPLE_TEXTURE2D(tex,samp,uv) SAMPLE_TEXTURE2D(tex, samp, uv) \
-    #endif
+#if !defined(LIL_PASS_FORWARD_NORMAL_INCLUDED) && !defined(LIL_PASS_FORWARD_NORMAL_INCLUDED_INCLUDED) \
+#define sampler_linear_repeat sampler_LinearRepeat \
+#define sampler_linear_clamp sampler_LinearClamp \
+#define TEXTURE2D_SAMPLER2D(tex,samp) TEXTURE2D(tex), SAMPLER(samp) \
+#define SAMPLE_TEXTURE2D(tex,samp,uv) SAMPLE_TEXTURE2D(tex, samp, uv) \
+#endif
 
 // Custom variables
 #define LIL_CUSTOM_PROPERTIES \
-    bool _ActiveDecalNumber; \
-    bool _ActiveDecalTexture; \
-    int _HideDecalNumberWhenZero; \
-    float4 _SpriteNumberTextureColor; \
-    float4 _DecalTextureColor; \
-    uint _DecalTextureBlendMode; \
-    uint _NumberTextureBlendMode; \
-    float4 _TexPositionXVector; \
-    float4 _TexPositionYVector; \
-    float4 _TexScaleXVector; \
-    float4 _TexScaleYVector; \
-    float _NumTexRotation; \
-    float _NumTexDisplaylength; \
-    int _NumTexAlignment; \
-    float _NumTexCharacterOffset; \
-    float _NumTexDigitSpacing; \
-    float4 _DecalPositionXVector; \
-    float4 _DecalPositionYVector; \
-    float4 _DecalScaleXVector; \
-    float4 _DecalScaleYVector; \
-    float _DecalRotation; \
-    float _FloatHeartRateC; \
-    float _DecalNumberEmissionStrength; \
-    float _DecalTextureEmissionStrength; \
-    float4 _DecalNumberEmissionColor; \
-    float _DecalNumberMainColorPower; \
-    float4 _DecalTextureEmissionColor; \
-    float _DecalTextureMainColorPower; \
-    uint _DecalNumberEmissionPattern; \
-    uint _DecalTextureEmissionPattern; \
-    bool _UseHeartRateEmission; \
-    float _HeartRateEmissionMin; \
-    float _HeartRateEmissionMax; \
-    bool _UseHeartRateEmissionTexture; \
-    float _HeartRateEmissionMinTexture; \
-    float _HeartRateEmissionMaxTexture; \
-    bool _UseHeartRateScaleTexture; \
-    float _HeartRateScaleIntensity;
+bool _ActiveDecalNumber; \
+bool _ActiveDecalTexture; \
+int _HideDecalNumberWhenZero; \
+float4 _SpriteNumberTextureColor; \
+float4 _DecalTextureColor; \
+uint _DecalTextureBlendMode; \
+uint _NumberTextureBlendMode; \
+float4 _TexPositionXVector; \
+float4 _TexPositionYVector; \
+float4 _TexScaleXVector; \
+float4 _TexScaleYVector; \
+float _NumTexRotation; \
+float _NumTexDisplaylength; \
+int _NumTexAlignment; \
+float _NumTexCharacterOffset; \
+float _NumTexDigitSpacing; \
+float4 _DecalPositionXVector; \
+float4 _DecalPositionYVector; \
+float4 _DecalScaleXVector; \
+float4 _DecalScaleYVector; \
+float _DecalRotation; \
+float _FloatHeartRateC; \
+float _DecalNumberEmissionStrength; \
+float _DecalTextureEmissionStrength; \
+float4 _DecalNumberEmissionColor; \
+float _DecalNumberMainColorPower; \
+float4 _DecalTextureEmissionColor; \
+float _DecalTextureMainColorPower; \
+uint _DecalNumberEmissionPattern; \
+uint _DecalTextureEmissionPattern; \
+bool _UseHeartRateEmission; \
+float _HeartRateEmissionMin; \
+float _HeartRateEmissionMax; \
+bool _UseHeartRateEmissionTexture; \
+float _HeartRateEmissionMinTexture; \
+float _HeartRateEmissionMaxTexture; \
+bool _UseHeartRateScaleTexture; \
+float _DecalNumberVisibilityThreshold; \
+float _HeartRateScaleIntensity;
 
 // Custom textures
 #define LIL_CUSTOM_TEXTURES \
-    TEXTURE2D(_SpriteNumberTexture); \
-    SAMPLER(sampler_SpriteNumberTexture); \
-    TEXTURE2D(_DecalTexture); \
-    SAMPLER(sampler_DecalTexture); \
-    TEXTURE2D(_DecalNumberEmissionMask); \
-    SAMPLER(sampler_DecalNumberEmissionMask); \
-    TEXTURE2D(_DecalTextureEmissionMask); \
-    SAMPLER(sampler_DecalTextureEmissionMask);
+TEXTURE2D(_SpriteNumberTexture); \
+SAMPLER(sampler_SpriteNumberTexture); \
+TEXTURE2D(_DecalTexture); \
+SAMPLER(sampler_DecalTexture); \
+TEXTURE2D(_DecalNumberEmissionMask); \
+SAMPLER(sampler_DecalNumberEmissionMask); \
+TEXTURE2D(_DecalTextureEmissionMask); \
+SAMPLER(sampler_DecalTextureEmissionMask);
 
 // Add vertex shader input
 //#define LIL_REQUIRE_APP_POSITION

--- a/Shaders/custom_insert.hlsl
+++ b/Shaders/custom_insert.hlsl
@@ -248,6 +248,8 @@ void lilGetDecalTexture(inout lilFragData fd LIL_SAMP_IN_FUNC(samp)) {
 
     float roundedHeartRate = roundHalfUp(_FloatHeartRateC);
 
+    if (_HideDecalTextureWhenZero == 1 && roundedHeartRate < _DecalTextureVisibilityThreshold) return;
+
     float2 offset = float2(_DecalPositionXVector.x, _DecalPositionYVector.x);    float2 scale = max(float2(_DecalScaleXVector.x, _DecalScaleYVector.x), float2(0.001, 0.001));
 
     if (_UseHeartRateScaleTexture && roundedHeartRate > 0)

--- a/Shaders/custom_insert.hlsl
+++ b/Shaders/custom_insert.hlsl
@@ -8,13 +8,11 @@ static const float kEmissionScale = 0.01;
 static const float2 kUvCenter = float2(0.5, 0.5);
 static const float3 kZeroColor = float3(0.0, 0.0, 0.0);
 
-float roundHalfUp(float value)
-{
+float roundHalfUp(float value) {
     return floor(value + 0.5);
 }
 
-float2 rotate2D(float2 v, float angle)
-{
+float2 rotate2D(float2 v, float angle) {
     float s, c;
     sincos(angle, s, c);
 
@@ -23,295 +21,256 @@ float2 rotate2D(float2 v, float angle)
         v.x * s + v.y * c);
 }
 
-float2 invAffineTransform(float2 uv, float2 translate, float rotAngle, float2 scale)
-{
+float2 invAffineTransform(float2 uv, float2 translate, float rotAngle, float2 scale) {
     scale = max(scale, float2(0.001, 0.001));
     return rotate2D(uv - kUvCenter - translate, -rotAngle) / scale + kUvCenter;
 }
 
-float fmodglsl(float x, float y)
-{
+float fmodglsl(float x, float y) {
     return x - y * floor(x / y);
 }
 
-float calcDigit(float val, float digitNum)
-{
+float calcDigit(float val, float digitNum) {
     return floor(fmodglsl(abs(val), digitNum * 10.0) / digitNum);
 }
 
-float2 calculateSpriteUV(float localUvX, float spriteColumnIndex, float characterOffset)
-{
+float2 calculateSpriteUV(float localUvX, float spriteColumnIndex, float characterOffset) {
     if (localUvX < kMarginRatio || localUvX > (1.0 - kMarginRatio))
-        return float2(-1.0, 0.0);
-    
+    return float2(-1.0, 0.0);
+
     localUvX = saturate((localUvX - kMarginRatio) / (1.0 - 2.0 * kMarginRatio) + characterOffset);
-    
+
     float charStartU = spriteColumnIndex * kInvColumns;
     float actualInset = kInvColumns * kInsetRatio;
     float sampleStartU = charStartU + actualInset;
     float sampleEndU = charStartU + kInvColumns - actualInset;
-    
+
     return float2(lerp(sampleStartU, sampleEndU, localUvX), sampleStartU);
 }
 
-float3 sampleSpriteWithSpacing(float val, float2 uv, float displayLength, float alignMode, float characterOffset, float digitSpacing)
-{
+float3 sampleSpriteWithSpacing(float val, float2 uv, float displayLength, float alignMode, float characterOffset, float digitSpacing) {
     if (any(uv < 0.0) || any(uv >= 1.0))
-        return kZeroColor;
+    return kZeroColor;
 
     val = abs(val);
     float numActualDigits = max(1.0, (val < 1.0) ? 1.0 : floor(log10(val)) + 1.0);
-    
+
     float effectiveDigits = (alignMode == 1.0 || alignMode == 2.0) ? numActualDigits : displayLength;
     float digitWidth = 1.0 / displayLength;
-    
+
     float gapReduction = 1.0 - digitSpacing;
     float newDigitSpacing = digitWidth * digitSpacing;
     float totalWidth = effectiveDigits * digitWidth - (effectiveDigits - 1) * digitWidth * gapReduction;
     float startOffset = (1.0 - totalWidth) * 0.5;
-    
+
     float3 finalColor = kZeroColor;
     float totalAlpha = 0.0;
-    
+
     [unroll(6)]
-    for (int i = 0; i < 6; i++)
-    {
+    for (int i = 0; i < 6; i++) {
         if (float(i) >= displayLength)
-            continue;
-            
+        continue;
+
         float digitIndex = 0.0;
         bool isValidDigit = false;
         float currentDigitSlot = float(i);
-        
-        if (alignMode == 0.0)
-        {
+
+        if (alignMode == 0.0) {
             digitIndex = float(i);
             isValidDigit = true;
         }
-        else if (alignMode == 1.0)
-        {
+        else if (alignMode == 1.0) {
             float emptySlotsOnLeft = max(0.0, displayLength - numActualDigits);
-            if (float(i) >= emptySlotsOnLeft)
-            {
+            if (float(i) >= emptySlotsOnLeft) {
                 digitIndex = float(i) - emptySlotsOnLeft;
                 isValidDigit = true;
             }
         }
-        else
-        {
-            if (float(i) < numActualDigits)
-            {
+        else {
+            if (float(i) < numActualDigits) {
                 digitIndex = float(i);
                 isValidDigit = true;
             }
         }
-        
-        if (isValidDigit)
-        {
+
+        if (isValidDigit) {
             float newDigitStart = startOffset + digitIndex * newDigitSpacing;
             float newDigitEnd = newDigitStart + digitWidth;
-            
-            if (uv.x >= newDigitStart && uv.x < newDigitEnd)
-            {
+
+            if (uv.x >= newDigitStart && uv.x < newDigitEnd) {
                 float localUvX = (uv.x - newDigitStart) / digitWidth;
-                
+
                 float digitToRender;
                 bool renderThisDigit = false;
 
-                if (alignMode == 0.0)
-                {
+                if (alignMode == 0.0) {
                     float power = pow(10.0, displayLength - 1.0 - currentDigitSlot);
                     digitToRender = calcDigit(val, power);
                     renderThisDigit = true;
                 }
-                else if (alignMode == 1.0)
-                {
+                else if (alignMode == 1.0) {
                     float emptySlotsOnLeft = max(0.0, displayLength - numActualDigits);
-                    if (currentDigitSlot >= emptySlotsOnLeft)
-                    {
+                    if (currentDigitSlot >= emptySlotsOnLeft) {
                         float effectiveDigitIndex = currentDigitSlot - emptySlotsOnLeft;
                         float power = pow(10.0, numActualDigits - 1.0 - effectiveDigitIndex);
                         digitToRender = calcDigit(val, power);
                         renderThisDigit = true;
                     }
                 }
-                else
-                {
-                    if (currentDigitSlot < numActualDigits)
-                    {
+                else {
+                    if (currentDigitSlot < numActualDigits) {
                         float power = pow(10.0, numActualDigits - 1.0 - currentDigitSlot);
                         digitToRender = calcDigit(val, power);
                         renderThisDigit = true;
                     }
                 }
 
-                if (renderThisDigit)
-                {
+                if (renderThisDigit) {
                     float2 spriteUvData = calculateSpriteUV(localUvX, digitToRender, characterOffset);
-                    
-                    if (spriteUvData.x >= 0.0 && digitToRender < kColumns)
-                    {
+
+                    if (spriteUvData.x >= 0.0 && digitToRender < kColumns) {
                         float2 spriteUv = float2(spriteUvData.x, uv.y);
                         float4 texSample = LIL_SAMPLE_2D(_SpriteNumberTexture, sampler_SpriteNumberTexture, spriteUv);
-                        
-                        if (texSample.a >= kAlphaThreshold)
-                        {
+
+                        if (texSample.a >= kAlphaThreshold) {
                             float alpha = texSample.a;
                             float3 digitColor = float3(1.0, 1.0, 1.0);
                             finalColor = lerp(finalColor, digitColor, alpha * (1.0 - totalAlpha));
                             totalAlpha = saturate(totalAlpha + alpha);
-                            
+
                             if (totalAlpha >= 0.99)
-                                break;
+                            break;
                         }
                     }
                 }
             }
         }
     }
-    
+
     return finalColor;
 }
 
-float3 sampleSprite(float val, float2 uv, float displayLength, float alignMode, float characterOffset)
-{
+float3 sampleSprite(float val, float2 uv, float displayLength, float alignMode, float characterOffset) {
     return sampleSpriteWithSpacing(val, uv, displayLength, alignMode, characterOffset, 1.0);
 }
 
-float3 sampleSpriteSignedWithSpacing(float val, float2 uv, float displayLength, float align, float characterOffset, float digitSpacing)
-{
+float3 sampleSpriteSignedWithSpacing(float val, float2 uv, float displayLength, float align, float characterOffset, float digitSpacing) {
     if (any(uv < 0.0) || any(uv >= 1.0))
-        return kZeroColor;
+    return kZeroColor;
 
     float originalDisplayLength = displayLength;
     displayLength += 1.0;
     float singleCharDisplayWidth = 1.0 / displayLength;
 
-    if (uv.x >= singleCharDisplayWidth) 
-    { 
+    if (uv.x >= singleCharDisplayWidth) {
         float2 numberPartUv = float2(saturate((uv.x - singleCharDisplayWidth) / (1.0 - singleCharDisplayWidth)), uv.y);
         return sampleSpriteWithSpacing(abs(val), numberPartUv, originalDisplayLength, align, characterOffset, digitSpacing);
     } 
-    else if (val < 0.0) 
-    { 
+    else if (val < 0.0) {
         float localUvX = uv.x / singleCharDisplayWidth;
         float2 spriteUvData = calculateSpriteUV(localUvX, 10.0, characterOffset);
-        
+
         if (spriteUvData.x < 0.0)
-            return kZeroColor;
-        
+        return kZeroColor;
+
         float2 spriteUv = float2(spriteUvData.x, uv.y);
         float4 tex = LIL_SAMPLE_2D(_SpriteNumberTexture, sampler_SpriteNumberTexture, spriteUv);
-        
+
         return (tex.a < kAlphaThreshold) ? kZeroColor : float3(1.0, 1.0, 1.0);
     } 
-    
+
     return kZeroColor;
 }
 
-float3 sampleSpriteSigned(float val, float2 uv, float displayLength, float align, float characterOffset)
-{
+float3 sampleSpriteSigned(float val, float2 uv, float displayLength, float align, float characterOffset) {
     return sampleSpriteSignedWithSpacing(val, uv, displayLength, align, characterOffset, 1.0);
 }
 
-float calculateHeartRateEmission(float heartRate, float minIntensity, float maxIntensity)
-{
+float calculateHeartRateEmission(float heartRate, float minIntensity, float maxIntensity) {
     if (heartRate <= 0.0) 
-        return minIntensity * kEmissionScale;
-    
+    return minIntensity * kEmissionScale;
+
     float phase = frac(_Time.y * heartRate / 60.0);
     float pulse = (phase < 0.1) ? (phase * 10.0) : exp(-(phase - 0.1) * 4.167);
-    
+
     return lerp(minIntensity, maxIntensity, saturate(pulse)) * kEmissionScale;
 }
 
-float calculateHeartRateEmissionSmooth(float heartRate, float minIntensity, float maxIntensity)
-{
+float calculateHeartRateEmissionSmooth(float heartRate, float minIntensity, float maxIntensity) {
     if (heartRate <= 0.0) 
-        return minIntensity * kEmissionScale;
-    
+    return minIntensity * kEmissionScale;
+
     float phase = frac(_Time.y * heartRate / 60.0);
     float Smooth = sin(phase * kTau);
     float normalized = (Smooth + 1.0) * 0.5;
-    
+
     return lerp(minIntensity, maxIntensity, normalized) * kEmissionScale;
 }
 
-float calculateHeartRateEmissionByPattern(float heartRate, float minIntensity, float maxIntensity, uint pattern)
-{
-    if (pattern == 1)
-    {
+float calculateHeartRateEmissionByPattern(float heartRate, float minIntensity, float maxIntensity, uint pattern) {
+    if (pattern == 1) {
         return calculateHeartRateEmissionSmooth(heartRate, minIntensity, maxIntensity);
     }
-    else
-    {
+    else {
         return calculateHeartRateEmission(heartRate, minIntensity, maxIntensity);
     }
 }
 
-float calculateHeartRateScale(float heartRate)
-{
+float calculateHeartRateScale(float heartRate) {
     if (heartRate <= 0.0) 
-        return 1.0;
-    
+    return 1.0;
+
     float phase = frac(_Time.y * heartRate / 60.0);
-    
+
     static const float kDampingFactor = 5.0;
     static const float kOscillationFreq = 4.0;
     static const float kExpandThreshold = 0.05;
     static const float kAmplitudeThreshold = 0.1;
-    
-    if (phase < kExpandThreshold)
-    {
+
+    if (phase < kExpandThreshold) {
         float expandPhase = phase / kExpandThreshold;
         return 1.0 + _HeartRateScaleIntensity * (1.0 - exp(-expandPhase * 5.0));
     }
-    else
-    {
+    else {
         float oscillationPhase = (phase - kExpandThreshold) / (1.0 - kExpandThreshold);
         float dampedAmplitude = exp(-kDampingFactor * oscillationPhase);
-        
+
         if (dampedAmplitude < kAmplitudeThreshold) 
-            return 1.0;
-        
+        return 1.0;
+
         float oscillation = sin(kOscillationFreq * oscillationPhase * kTau);
         return max(1.0 + _HeartRateScaleIntensity * dampedAmplitude * (1.0 + 0.5 * oscillation), 0.5);
     }
 }
 
-void lilGetDecalTexture(inout lilFragData fd LIL_SAMP_IN_FUNC(samp))
-{
+void lilGetDecalTexture(inout lilFragData fd LIL_SAMP_IN_FUNC(samp)) {
     if (!_ActiveDecalTexture) return;
-    
+
     float roundedHeartRate = roundHalfUp(_FloatHeartRateC);
-    
+
     float2 offset = float2(_DecalPositionXVector.x, _DecalPositionYVector.x);    float2 scale = max(float2(_DecalScaleXVector.x, _DecalScaleYVector.x), float2(0.001, 0.001));
-    
+
     if (_UseHeartRateScaleTexture && roundedHeartRate > 0)
-        scale *= calculateHeartRateScale(roundedHeartRate);
-    
+    scale *= calculateHeartRateScale(roundedHeartRate);
+
     float2 uv2 = invAffineTransform(fd.uvMain, offset, -_DecalRotation, scale);
-    
+
     float uvMask = lilIsIn0to1(uv2);
     if (uvMask <= 0.0) return;
-      float4 decalColor = LIL_SAMPLE_2D(_DecalTexture, sampler_DecalTexture, uv2) * _DecalTextureColor;
-    
+    float4 decalColor = LIL_SAMPLE_2D(_DecalTexture, sampler_DecalTexture, uv2) * _DecalTextureColor;
+
     float decalMask = decalColor.a * uvMask;
-    if (decalMask > 0.001)
-    {
+    if (decalMask > 0.001) {
         fd.col.rgb = lerp(fd.col.rgb, lilBlendColor(fd.col.rgb, decalColor.rgb, decalMask, _DecalTextureBlendMode), decalMask);        
         float emissionStrength;
-        if (_UseHeartRateEmissionTexture)
-        {
+        if (_UseHeartRateEmissionTexture) {
             emissionStrength = calculateHeartRateEmissionByPattern(roundedHeartRate, _HeartRateEmissionMinTexture, _HeartRateEmissionMaxTexture, _DecalTextureEmissionPattern) * 100.0;
         }
-        else
-        {
+        else {
             emissionStrength = _DecalTextureEmissionStrength;
         }
-        
-        if (emissionStrength > 0.0)
-        {
+
+        if (emissionStrength > 0.0) {
             float4 maskSample = LIL_SAMPLE_2D(_DecalTextureEmissionMask, sampler_DecalTextureEmissionMask, uv2);
             float maskValue = maskSample.r; 
             float3 emissionCol = _DecalTextureEmissionColor.rgb;
@@ -323,41 +282,36 @@ void lilGetDecalTexture(inout lilFragData fd LIL_SAMP_IN_FUNC(samp))
     }
 }
 
-void lilGetDecalNumber(inout lilFragData fd LIL_SAMP_IN_FUNC(samp))
-{
+void lilGetDecalNumber(inout lilFragData fd LIL_SAMP_IN_FUNC(samp)) {
     if (!_ActiveDecalNumber) return;
-    
+
     float roundedHeartRate = roundHalfUp(_FloatHeartRateC);
-    
-    if (_HideDecalNumberWhenZero == 1 && roundedHeartRate <= 0.0) return;
-    
+
+    if (_HideDecalNumberWhenZero == 1 && roundedHeartRate < _DecalNumberVisibilityThreshold) return;
+
     float2 offset = float2(_TexPositionXVector.x, _TexPositionYVector.x);    float2 scale = max(float2(_TexScaleXVector.x, _TexScaleYVector.x), float2(0.001, 0.001));
     float2 numUv = invAffineTransform(fd.uvMain, offset, -_NumTexRotation, scale);
-    
+
     float uvMask = lilIsIn0to1(numUv);
     if (uvMask <= 0.0) return;
-    
+
     float3 numberColor = sampleSpriteWithSpacing(roundedHeartRate, numUv, _NumTexDisplaylength, float(_NumTexAlignment), _NumTexCharacterOffset, _NumTexDigitSpacing);
-    
+
     float numberMask = (dot(numberColor, numberColor) > 0.000001) ? uvMask : 0.0;
-    
-    if (numberMask > 0.001)
-    {
+
+    if (numberMask > 0.001) {
         float3 finalNumberColor = numberColor * _SpriteNumberTextureColor.rgb;
-        
+
         fd.col.rgb = lerp(fd.col.rgb, lilBlendColor(fd.col.rgb, finalNumberColor, numberMask, _NumberTextureBlendMode), numberMask);        
         float emissionStrength;
-        if (_UseHeartRateEmission)
-        {
+        if (_UseHeartRateEmission) {
             emissionStrength = calculateHeartRateEmissionByPattern(roundedHeartRate, _HeartRateEmissionMin, _HeartRateEmissionMax, _DecalNumberEmissionPattern) * 100.0;
         }
-        else
-        {
+        else {
             emissionStrength = _DecalNumberEmissionStrength;
         }
-        
-        if (emissionStrength > 0.0)
-        {
+
+        if (emissionStrength > 0.0) {
             float4 maskSample = LIL_SAMPLE_2D(_DecalNumberEmissionMask, sampler_DecalNumberEmissionMask, numUv);
             float maskValue = maskSample.r;
             float3 emissionCol = _DecalNumberEmissionColor.rgb;
@@ -370,13 +324,13 @@ void lilGetDecalNumber(inout lilFragData fd LIL_SAMP_IN_FUNC(samp))
 }
 
 #if !defined(BEFORE_MAIN3RD)
-    #define BEFORE_MAIN3RD \
-        lilGetDecalTexture(fd LIL_SAMP_IN(sampler_MainTex)); \
-        lilGetDecalNumber(fd LIL_SAMP_IN(sampler_MainTex));
+#define BEFORE_MAIN3RD \
+lilGetDecalTexture(fd LIL_SAMP_IN(sampler_MainTex)); \
+lilGetDecalNumber(fd LIL_SAMP_IN(sampler_MainTex));
 #endif
 
 #if !defined(OVERRIDE_ALPHAMASK)
-    #define OVERRIDE_ALPHAMASK \
-        lilGetDecalTexture(fd LIL_SAMP_IN(sampler_MainTex)); \
-        lilGetDecalNumber(fd LIL_SAMP_IN(sampler_MainTex));
+#define OVERRIDE_ALPHAMASK \
+lilGetDecalTexture(fd LIL_SAMP_IN(sampler_MainTex)); \
+lilGetDecalNumber(fd LIL_SAMP_IN(sampler_MainTex));
 #endif

--- a/Shaders/custom_insert.hlsl
+++ b/Shaders/custom_insert.hlsl
@@ -247,12 +247,15 @@ void lilGetDecalTexture(inout lilFragData fd LIL_SAMP_IN_FUNC(samp)) {
     if (!_ActiveDecalTexture) return;
 
     float roundedHeartRate = roundHalfUp(_FloatHeartRateC);
-
-    if (_HideDecalTextureWhenZero == 1 && roundedHeartRate < _DecalTextureVisibilityThreshold) return;
+    bool isThresholdMode = (_HideDecalTextureWhenZero == 1);
+    bool isThresholdPassed = (roundedHeartRate >= _DecalTextureVisibilityThreshold);
+    bool allowDisplay = !isThresholdMode || _DecalTextureThresholdAffectsDisplay == 0 || isThresholdPassed;
+    bool allowEmission = !isThresholdMode || _DecalTextureThresholdAffectsEmission == 0 || isThresholdPassed;
+    bool allowScale = !isThresholdMode || _DecalTextureThresholdAffectsScale == 0 || isThresholdPassed;
 
     float2 offset = float2(_DecalPositionXVector.x, _DecalPositionYVector.x);    float2 scale = max(float2(_DecalScaleXVector.x, _DecalScaleYVector.x), float2(0.001, 0.001));
 
-    if (_UseHeartRateScaleTexture && roundedHeartRate > 0)
+    if (_UseHeartRateScaleTexture && roundedHeartRate > 0 && allowScale)
     scale *= calculateHeartRateScale(roundedHeartRate);
 
     float2 uv2 = invAffineTransform(fd.uvMain, offset, -_DecalRotation, scale);
@@ -263,9 +266,15 @@ void lilGetDecalTexture(inout lilFragData fd LIL_SAMP_IN_FUNC(samp)) {
 
     float decalMask = decalColor.a * uvMask;
     if (decalMask > 0.001) {
-        fd.col.rgb = lerp(fd.col.rgb, lilBlendColor(fd.col.rgb, decalColor.rgb, decalMask, _DecalTextureBlendMode), decalMask);        
+        if (allowDisplay) {
+            fd.col.rgb = lerp(fd.col.rgb, lilBlendColor(fd.col.rgb, decalColor.rgb, decalMask, _DecalTextureBlendMode), decalMask);
+        }
+
         float emissionStrength;
-        if (_UseHeartRateEmissionTexture) {
+        if (!allowEmission) {
+            emissionStrength = 0.0;
+        }
+        else if (_UseHeartRateEmissionTexture) {
             emissionStrength = calculateHeartRateEmissionByPattern(roundedHeartRate, _HeartRateEmissionMinTexture, _HeartRateEmissionMaxTexture, _DecalTextureEmissionPattern) * 100.0;
         }
         else {
@@ -288,8 +297,10 @@ void lilGetDecalNumber(inout lilFragData fd LIL_SAMP_IN_FUNC(samp)) {
     if (!_ActiveDecalNumber) return;
 
     float roundedHeartRate = roundHalfUp(_FloatHeartRateC);
-
-    if (_HideDecalNumberWhenZero == 1 && roundedHeartRate < _DecalNumberVisibilityThreshold) return;
+    bool isThresholdMode = (_HideDecalNumberWhenZero == 1);
+    bool isThresholdPassed = (roundedHeartRate >= _DecalNumberVisibilityThreshold);
+    bool allowDisplay = !isThresholdMode || _DecalNumberThresholdAffectsDisplay == 0 || isThresholdPassed;
+    bool allowEmission = !isThresholdMode || _DecalNumberThresholdAffectsEmission == 0 || isThresholdPassed;
 
     float2 offset = float2(_TexPositionXVector.x, _TexPositionYVector.x);    float2 scale = max(float2(_TexScaleXVector.x, _TexScaleYVector.x), float2(0.001, 0.001));
     float2 numUv = invAffineTransform(fd.uvMain, offset, -_NumTexRotation, scale);
@@ -304,9 +315,15 @@ void lilGetDecalNumber(inout lilFragData fd LIL_SAMP_IN_FUNC(samp)) {
     if (numberMask > 0.001) {
         float3 finalNumberColor = numberColor * _SpriteNumberTextureColor.rgb;
 
-        fd.col.rgb = lerp(fd.col.rgb, lilBlendColor(fd.col.rgb, finalNumberColor, numberMask, _NumberTextureBlendMode), numberMask);        
+        if (allowDisplay) {
+            fd.col.rgb = lerp(fd.col.rgb, lilBlendColor(fd.col.rgb, finalNumberColor, numberMask, _NumberTextureBlendMode), numberMask);
+        }
+
         float emissionStrength;
-        if (_UseHeartRateEmission) {
+        if (!allowEmission) {
+            emissionStrength = 0.0;
+        }
+        else if (_UseHeartRateEmission) {
             emissionStrength = calculateHeartRateEmissionByPattern(roundedHeartRate, _HeartRateEmissionMin, _HeartRateEmissionMax, _DecalNumberEmissionPattern) * 100.0;
         }
         else {

--- a/Shaders/lilCustomShaderProperties.lilblock
+++ b/Shaders/lilCustomShaderProperties.lilblock
@@ -8,6 +8,8 @@ _FloatHeartRateC                         ("HeartRate", float) = 0
 [Enum(Always Show,0,Hide Below Threshold,1)]
                 _HideDecalNumberWhenZero ("Number Visibility Mode", Int) = 0
                 _DecalNumberVisibilityThreshold ("Visibility Threshold", Range(0, 300)) = 0
+[lilToggle]     _DecalNumberThresholdAffectsDisplay ("Threshold Affects Display", Int) = 1
+[lilToggle]     _DecalNumberThresholdAffectsEmission ("Threshold Affects Emission", Int) = 1
 
 // Number Texture Properties
 [HDR][lilHDR]   _SpriteNumberTextureColor   ("Color", Color) = (1,1,1,1)
@@ -45,6 +47,9 @@ _FloatHeartRateC                         ("HeartRate", float) = 0
 [Enum(Always Show,0,Hide Below Threshold,1)]
                 _HideDecalTextureWhenZero    ("Texture Visibility Mode", Int) = 0
                 _DecalTextureVisibilityThreshold ("Visibility Threshold", Range(0, 300)) = 0
+[lilToggle]     _DecalTextureThresholdAffectsDisplay ("Threshold Affects Display", Int) = 1
+[lilToggle]     _DecalTextureThresholdAffectsEmission ("Threshold Affects Emission", Int) = 1
+[lilToggle]     _DecalTextureThresholdAffectsScale ("Threshold Affects Scale", Int) = 1
 [lilVec4]       _DecalPositionXVector        ("Decal Position X", Vector) = (0.0, 0.0, 0.0, 0.0)
 [lilVec4]       _DecalPositionYVector        ("Decal Position Y", Vector) = (0.0, 0.0, 0.0, 0.0)
 [lilVec4]       _DecalScaleXVector           ("Decal Scale X", Vector) = (0.5, 0.5, 0.5, 0.5)

--- a/Shaders/lilCustomShaderProperties.lilblock
+++ b/Shaders/lilCustomShaderProperties.lilblock
@@ -42,6 +42,9 @@ _FloatHeartRateC                         ("HeartRate", float) = 0
                 _DecalTexture                ("Texture", 2D) = "white" {}
 [Enum(Normal,0,Multiply,3)]
                 _DecalTextureBlendMode       ("Blend Mode", Int) = 0
+[Enum(Always Show,0,Hide Below Threshold,1)]
+                _HideDecalTextureWhenZero    ("Texture Visibility Mode", Int) = 0
+                _DecalTextureVisibilityThreshold ("Visibility Threshold", Range(0, 300)) = 0
 [lilVec4]       _DecalPositionXVector        ("Decal Position X", Vector) = (0.0, 0.0, 0.0, 0.0)
 [lilVec4]       _DecalPositionYVector        ("Decal Position Y", Vector) = (0.0, 0.0, 0.0, 0.0)
 [lilVec4]       _DecalScaleXVector           ("Decal Scale X", Vector) = (0.5, 0.5, 0.5, 0.5)

--- a/Shaders/lilCustomShaderProperties.lilblock
+++ b/Shaders/lilCustomShaderProperties.lilblock
@@ -5,8 +5,9 @@ _FloatHeartRateC                         ("HeartRate", float) = 0
 // Toggle Controls
 [lilToggleLeft] _ActiveDecalNumber      ("Number Active Toggle", Int) = 0
 [lilToggleLeft] _ActiveDecalTexture     ("Texture Active Toggle", Int) = 0
-[Enum(Always Show,0,Hide Below Zero,1)]
+[Enum(Always Show,0,Hide Below Threshold,1)]
                 _HideDecalNumberWhenZero ("Number Visibility Mode", Int) = 0
+                _DecalNumberVisibilityThreshold ("Visibility Threshold", Range(0, 300)) = 0
 
 // Number Texture Properties
 [HDR][lilHDR]   _SpriteNumberTextureColor   ("Color", Color) = (1,1,1,1)


### PR DESCRIPTION
Changes : 

- Introduced a visibility threshold for decal numbers.
- Added controls for the visibility of decal textures and their thresholds.
- Enhanced existing visibility controls to include threshold effects for display, emission, and scale.

Related Topic : 
None